### PR TITLE
Support weighted feature coverage configuration

### DIFF
--- a/application/services/graph_matching_service.py
+++ b/application/services/graph_matching_service.py
@@ -257,7 +257,8 @@ class GraphMatchingService:
         cand_source = cand_meta.get("source", "unknown_source")
         sim_percent = item["similarity_percent"]
 
-        logger.info(f"Проверка кандидата: {cand_id} ({cand_source}) — GNN сходство {sim_percent:.2f}%")
+        logger.info(f" ▶️ Проверка кандидата: {cand_id} ({cand_source}) ")
+        logger.info(f"GNN сходство {sim_percent:.2f}%")
 
         if sim_percent < self.threshold:
             logger.info(f"Пропуск {cand_id} ({cand_source}) — ниже порога GNN ({self.threshold:.1f}%)")
@@ -285,7 +286,7 @@ class GraphMatchingService:
 
         size_reason = self._validate_geometry_size(pred_stats, cand_stats)
         if size_reason:
-            logger.info(f"Отказ {cand_id} ({cand_source}) — несоответствие размеров: {size_reason}")
+            logger.info(f" 🔴 Отказ {cand_id} ({cand_source}) — несоответствие размеров: {size_reason}")
             return MatchResult(id=cand_id, source=cand_source, reason="geometry_size")
 
         try:
@@ -296,6 +297,10 @@ class GraphMatchingService:
                 use_angles=settings.geometry.use_angles,
                 normalize_position=settings.geometry.normalize_position,
                 normalize_scale=settings.geometry.normalize_scale,
+                feature_weights=settings.geometry.feature_weights,
+                feature_coverage_importance=(
+                    settings.geometry.feature_coverage_importance
+                ),
             )
             if isinstance(result, dict):
                 score = result.get("score", 0.0)
@@ -312,7 +317,7 @@ class GraphMatchingService:
             return MatchResult(id=cand_id, source=cand_source, percent=score, reason="geometry_mismatch")
 
         except Exception as e:
-            logger.warning(f"Ошибка сравнения {cand_id}: {e}")
+            logger.warning(f"❌ Ошибка сравнения {cand_id}: {e}")
             return MatchResult(id=cand_id, source=cand_source, reason="geometry_exception")
 
     def _write_report(
@@ -339,7 +344,7 @@ class GraphMatchingService:
             else:
                 cand_stats = {"nodes": 0, "edges": 0, "width": 0.0, "height": 0.0, "area": 0.0}
 
-                # --- запись в CSV ---
+            # --- запись в CSV ---
             with self.report_path.open("a", newline="", encoding="utf-8") as f:
                 writer = csv.writer(f)
                 writer.writerow([
@@ -388,8 +393,8 @@ class GraphMatchingService:
         abs_width_diff = abs(pred_stats["width"] - cand_stats["width"])
         abs_height_diff = abs(pred_stats["height"] - cand_stats["height"])
         abs_area_diff = abs(pred_stats["area"] - cand_stats["area"])
-        max_abs_width = getattr(settings.geometry, "max_absolute_bbox_diff_mm", 5.0)
-        max_abs_area = getattr(settings.geometry, "max_absolute_area_diff_mm2", 500.0)
+        max_abs_width = settings.geometry.max_absolute_bbox_diff_mm
+        max_abs_area = settings.geometry.max_absolute_area_diff_mm2
 
         if abs_width_diff > max_abs_width or abs_height_diff > max_abs_width:
             return f"абсолютная разница габаритов {abs_width_diff:.2f}×{abs_height_diff:.2f} мм (допуск ±{max_abs_width:.1f} мм)"

--- a/config.yaml
+++ b/config.yaml
@@ -118,6 +118,14 @@ geometry:
   max_node_mismatch_percent: 5.0  # допустимая разница в числе узлов
   max_edge_mismatch_percent: 5.0  # допустимая разница в числе рёбер
   max_bbox_mismatch_percent: 5.0  # допустимая разница габаритов/площади
+  feature_weights:                # веса для компонентов сравнения
+    nodes: 1.0
+    edges: 1.0
+    angles: 1.0
+  feature_coverage_importance:    # вклад покрытия узлов/рёбер/углов
+    coords: 0.3
+    edges: 0.3
+    angles: 0.5
 
 evaluation:
   threshold: 0.5

--- a/domain/config/settings.py
+++ b/domain/config/settings.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from pydantic import (
     BaseModel,
+    Field,
     model_validator,
 )
 from typing import List
@@ -264,6 +265,16 @@ class GeometryConfig(BaseModel):
     max_node_mismatch_percent: float = 5.0
     max_edge_mismatch_percent: float = 5.0
     max_bbox_mismatch_percent: float = 5.0
+    max_absolute_bbox_diff_mm: float = 5.0
+    max_absolute_area_diff_mm2: float = 500.0
+    feature_weights: dict[str, float] = Field(
+        default_factory=lambda: {
+            "nodes": 1.0,
+            "edges": 1.0,
+            "angles": 1.0,
+        }
+    )
+    feature_coverage_importance: dict[str, float] | float = 1.0
 
 
 class EvaluationConfig(BaseModel):

--- a/infrastructure/utils/match_graph.py
+++ b/infrastructure/utils/match_graph.py
@@ -212,6 +212,8 @@ def geometry_verified_id(
             use_angles=settings.geometry.use_angles,
             normalize_position=settings.geometry.normalize_position,
             normalize_scale=settings.geometry.normalize_scale,
+            feature_weights=settings.geometry.feature_weights,
+            feature_coverage_importance=settings.geometry.feature_coverage_importance,
         )
         try:
             percent = float(raw)


### PR DESCRIPTION
## Summary
- allow geometry feature coverage importance to be configured either as a scalar or per-component weights
- update the slow geometry comparison helper to honor weighted coverage maps alongside existing weighting
- document the new geometry settings in the default configuration file
